### PR TITLE
Fix missing method bug?

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpineInterface"
 uuid = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 authors = ["Spine Project consortium <spine_info@vtt.fi>"]
-version = "0.11.3"
+version = "0.11.4"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/update_model.jl
+++ b/src/update_model.jl
@@ -344,6 +344,13 @@ function JuMP.add_to_expression!(
 ) where {C}
     add_to_expression!(aff, coef, other)
 end
+function JuMP.add_to_expression!(
+    aff::GenericAffExpr{Call,VariableRef},
+    coef::Call,
+    other::GenericAffExpr{Call,VariableRef},
+)
+    add_to_expression!(aff, coef * other)
+end
 
 # operators
 # strategy: Make operators between a `Call` and a `VariableRef` return a `GenericAffExpr`,


### PR DESCRIPTION
Fixing an emergent missing method bug in `main`.

I honestly have no idea what caused the bug in the first place, I can only guess that some updates in the dependencies were the cause. @manuelma you really should check if the method I've implemented does what it's supposed to, since I'm not at all familiar with your JuMP expression extensions.

## Checklist before merging
- [x] Documentation is up-to-date *(bugfix, no functional changes)*
- [x] Release notes have been updated *(we don't have any?)*
- [x] Unit tests have been added/updated accordingly *(no need, fixing existing functionality)*
- [x] Code has been formatted nicely *(we really should implement automatic formatting)*
- [x] Unit tests pass
