### PR TITLE
WIP Handle JuMP name conflict and uncap version

### DIFF
--- a/src/update_model.jl
+++ b/src/update_model.jl
@@ -54,6 +54,11 @@ struct _CallInterval <: _CallSet
     upper::Call
 end
 
+# Can't be in `base.jl` since `_CallInterval` is only in `update_model.jl`, which is loaded weirdly with JuMP.
+function Base.:(==)(x::_CallInterval, y::_CallInterval)
+	all(getproperty(x, p) == getproperty(y, p) for p in propertynames(x))
+end
+
 abstract type AbstractUpdate end
 
 struct _VariableLBUpdate <: AbstractUpdate
@@ -221,10 +226,10 @@ function JuMP.build_constraint(_error::Function, var::VariableRef, set::_CallSet
     build_constraint(_error, Call(1) * var, set)
 end
 function JuMP.build_constraint(_error::Function, var::VariableRef, lb::Call, ub::Real)
-    build_constraint(_error, expr, lb, Call(ub))
+    build_constraint(_error, Call(1) * var, lb, Call(ub))
 end
 function JuMP.build_constraint(_error::Function, var::VariableRef, lb::Real, ub::Call)
-    build_constraint(_error, expr, Call(lb), ub)
+    build_constraint(_error, Call(1) * var, Call(lb), ub)
 end
 function JuMP.build_constraint(_error::Function, var::VariableRef, lb::Call, ub::Call)
     build_constraint(_error, Call(1) * var, lb, ub)

--- a/src/update_model.jl
+++ b/src/update_model.jl
@@ -234,6 +234,18 @@ end
 function JuMP.build_constraint(_error::Function, var::VariableRef, lb::Call, ub::Call)
     build_constraint(_error, Call(1) * var, lb, ub)
 end
+function JuMP.build_constraint(_error::Function, expr::AffExpr, set::_CallSet)
+    build_constraint(_error, Call(1) * expr, set)
+end
+function JuMP.build_constraint(_error::Function, expr::AffExpr, lb::Real, ub::Call)
+    build_constraint(_error, Call(1) * expr, Call(lb), ub)
+end
+function JuMP.build_constraint(_error::Function, expr::AffExpr, lb::Call, ub::Real)
+    build_constraint(_error, Call(1) * expr, lb, Call(ub))
+end
+function JuMP.build_constraint(_error::Function, expr::AffExpr, lb::Call, ub::Call)
+    build_constraint(_error, Call(1) * expr, lb, ub)
+end
 function JuMP.build_constraint(_error::Function, expr::GenericAffExpr{Call,VariableRef}, lb::Real, ub::Real)
     build_constraint(_error, expr, Call(lb), Call(ub))
 end
@@ -258,7 +270,7 @@ function JuMP.add_constraint(
     con::ScalarConstraint{GenericAffExpr{Call,VariableRef},S},
     name::String="",
 ) where {S<:_CallSet}
-    iszero(con.func) && iszero(MOI.constant(con.set)) && return nothing
+    iszero(con.func) && return nothing
     con_ref = Ref{ConstraintRef}()
     realized_func = realize(con.func, con_ref)
     realized_set = realize(con.set, con_ref)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -8,5 +8,4 @@ SpineInterface = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-JuMP = "< 1.14"
 julia = "^1.2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,9 @@ using JSON
 using JuMP
 using Cbc
 
+# Handle JuMP and SpineInterface `Parameter` and `parameter_value` conflicts.
+import SpineInterface: Parameter, parameter_value
+
 # Original tests used a slightly different syntax for `import_data`, so correct it here for convenience.
 SpineInterface.import_data(db_url::String; kwargs...) = SpineInterface.import_data(db_url, Dict(kwargs...), "testing")
 

--- a/test/update_model.jl
+++ b/test/update_model.jl
@@ -17,6 +17,18 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
+@testset "build_constraint" begin # TODO this needs to cover more functionality.
+	m = Model()
+	x = @variable(m, x)
+	# Test that `build_constraint` returns identical output (almost) regardless of `Call` inputs.
+	cs = [
+		JuMP.build_constraint(x->nothing, x, i, j)
+		for (i, j) in [(1, Call(1)), (Call(1), 1), (Call(1), Call(1))]
+	]
+	@test all(c.func == first(cs).func for c in cs)
+	@test all(c.set == first(cs).set for c in cs)
+end
+
 @testset "update_model" begin
 	m = Model(Cbc.Optimizer)
 	@variable(m, x, lower_bound=0)


### PR DESCRIPTION
Resolving JuMP `Parameter` and `parameter_value` name conflict, allowing JuMP version for the unit tests to be uncapped again.

Pending merge to master, waiting to resolve weirder related issues in SpineOpt, see https://github.com/spine-tools/SpineOpt.jl/issues/745.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted nicely
- [x] Unit tests pass
