### PR TITLE
Bump DB client version to 7 (as required by spinedb_api 0.8-dev)

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -23,8 +23,8 @@
 const _df = DateFormat("yyyy-mm-ddTHH:MM")
 const _db_df = dateformat"yyyy-mm-ddTHH:MM:SS"
 const _alt_db_df = dateformat"yyyy-mm-dd HH:MM:SS"
-const _required_spinedb_api_version = v"0.23.2"
-const _client_version = 6
+const _required_spinedb_api_version = v"0.31.0"
+const _client_version = 7
 const _EOT = '\u04'  # End of transmission
 const _START_OF_TAIL = '\u1f'  # Unit separator
 const _START_OF_ADDRESS = '\u91'  # Private Use 1


### PR DESCRIPTION
In `0.8-dev`, `spinedb_api` requires DB client version 7 (changed in spine-tools/Spine-Database-API#391).

No associated issue.

## Checklist before merging
- [x] Code has been formatted nicely
- [ ] Unit tests pass
