### PR TITLE
Throw domainerror with time series

### DIFF
--- a/src/api/core.jl
+++ b/src/api/core.jl
@@ -305,8 +305,8 @@ function _get_value(pv::ParameterValue{T}, t, upd) where T<:TimeSeries
 end
 function _get_time_series_value(pv, t::DateTime, upd)
     pv.value.ignore_year && (t -= Year(t))
-    t < pv.value.indexes[1] && return NaN
-    t > pv.value.indexes[end] && !pv.value.ignore_year && return NaN
+    t < pv.value.indexes[1] && throw(DomainError(pv, "Time index $t out of range!"))
+    t > pv.value.indexes[end] && !pv.value.ignore_year && throw(DomainError(pv, "Time index $t out of range!"))
     pv.value.values[max(1, searchsortedlast(pv.value.indexes, t))]
 end
 function _get_time_series_value(pv, t::TimeSlice, upd)
@@ -317,8 +317,8 @@ function _get_time_series_value(pv, t::TimeSlice, upd)
         timeout = _timeout(pv.value, t_start, t_end, a, b)
         _add_update(t, timeout, upd)
     end
-    t_end <= pv.value.indexes[1] && return NaN
-    t_start > pv.value.indexes[end] && !pv.value.ignore_year && return NaN
+    t_end <= pv.value.indexes[1] && throw(DomainError(pv, "Time index $t out of range!"))
+    t_start > pv.value.indexes[end] && !pv.value.ignore_year && throw(DomainError(pv, "Time index $t out of range!"))
     mean(Iterators.filter(!isnan, pv.value.values[a:b]))
 end
 function _get_repeating_time_series_value(pv, t::DateTime, upd)


### PR DESCRIPTION
Throw domainerror when TimeSeries ParameterValue is refenced with a time slice which is out of domain of the time series.


Related to [ Checking the replacement value for variables #1016 ](https://github.com/spine-tools/SpineOpt.jl/issues/1016)

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted nicely
- [ ] Unit tests pass
