### PR TITLE
Parameter types now need to be specified more accurately when unparsing

### DIFF
--- a/src/api/parameter_value.jl
+++ b/src/api/parameter_value.jl
@@ -349,6 +349,9 @@ end
 _add_db_type!(db_val, x) = db_val
 
 _db_type(x) = nothing
+_db_type(x::Real) = "float"
+_db_type(x::Union{String,Symbol}) = "str"
+_db_type(x::Bool) = "bool"
 _db_type(x::Dict) = x["type"]
 _db_type(::DateTime) = "date_time"
 _db_type(::T) where {T<:Period} = "duration"


### PR DESCRIPTION
`Real`, `String`, `Symbol`, and `Bool` parameter value types now need to be specified when unparsing.

Fixes a bug where the above parameter types wouldn't be exported correctly into Datastores due to their unparsing lacking the type information required by Spine Database API.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated (we don't have any)
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted nicely
- [x] Unit tests pass
