### PR TITLE
Make tests a reusable GitHub action

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,0 +1,58 @@
+name: Test
+on:
+  workflow_call:
+    inputs:
+      host-os:
+        required: true
+        type: string
+      julia-version:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+      repository:
+        required: false
+        type: string
+        default: ${{ github.repository }}
+      spinedb-api-ref-name:
+        required: false
+        type: string
+        default: 'master'
+      coverage:
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      CODECOV_TOKEN:
+        required: true
+
+jobs:
+  test:
+    name: Julia ${{ inputs.julia-version }} - ${{ inputs.host-os }}
+    runs-on: ${{ inputs.host-os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repository }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ inputs.julia-version }}
+          arch: x64
+      - name: Install spinedb_api
+        run:
+          julia ./.install_spinedb_api.jl ${{ inputs.spinedb-api-ref-name }}
+        env:
+          PYTHON: python
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-processcoverage@v1
+        if: inputs.coverage && inputs.julia-version == '1' && inputs.host-os == 'ubuntu-latest'
+      - uses: codecov/codecov-action@v4
+        if: inputs.coverage && inputs.julia-version == '1' && inputs.host-os == 'ubuntu-latest'
+        with:
+          file: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,11 @@
-# GitHub Action
-
 name: CI
 
-# Run workflow on every push
 on:
   push
 
 jobs:
-  test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
+  call_test:
+    name: Test on Julia ${{ matrix.version }} - ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -18,54 +14,25 @@ jobs:
           - "1"    # Latest Release
         os:
           - ubuntu-latest
-          # - macOS-latest
           - windows-latest
-        arch:
-          - x64
-          # - x86  # FIXME: We don't support x86 because we type-annotate with Int64 and Float64 sparingly
         python-version: ["3.11"]
-        exclude:
-          # Test 32-bit only on Linux
-          - os: macOS-latest
-            arch: x86
-          - os: windows-latest
-            arch: x86
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11' 
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - run: |
-          git config --global user.name Tester
-          git config --global user.email te@st.er
-      - name: Install spinedb_api
-        run:
-          julia ./.install_spinedb_api.jl
-        env:
-          PYTHON: python
-      - uses: julia-actions/julia-runtest@latest
-      - uses: julia-actions/julia-processcoverage@v1
-        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
-      - uses: codecov/codecov-action@v4
-        with:
-          file: lcov.info
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    uses: ./.github/workflows/Test.yml
+    with:
+      host-os: ${{ matrix.os }}
+      julia-version: ${{ matrix.version }}
+      python-version: ${{ matrix.python-version }}
+    secrets: inherit
   Documenter:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.11' 
+          python-version: '3.11'
       - name: Install dependencies
         run: |
-          julia ./.install_spinedb_api.jl          
+          julia ./.install_spinedb_api.jl
           julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - uses: julia-actions/julia-docdeploy@latest
         env:

--- a/.install_spinedb_api.jl
+++ b/.install_spinedb_api.jl
@@ -4,5 +4,10 @@ pkg"registry add https://github.com/spine-tools/SpineJuliaRegistry"
 pkg"add PyCall"
 using PyCall
 python = PyCall.pyprogramname
+if isempty(ARGS)
+    spine_db_api_git_ref = "master"
+else
+    spine_db_api_git_ref = ARGS[1]
+end
 run(`$python -m pip install --user setuptools-scm`)
-run(`$python -m pip install --user git+https://github.com/spine-tools/Spine-Database-API`)
+run(`$python -m pip install --user git+https://github.com/spine-tools/Spine-Database-API@$spine_db_api_git_ref`)


### PR DESCRIPTION
This PR enables the SpineInterface tests to run from `spinedb_api` repository as well. This way we may catch incompatibilities between the packages before they hit the master branches.

No associated issue.

## Checklist before merging
- [ ] Unit tests pass
